### PR TITLE
[FEAT] 회원 탈퇴 

### DIFF
--- a/src/main/java/ject/mycode/domain/auth/controller/AuthController.java
+++ b/src/main/java/ject/mycode/domain/auth/controller/AuthController.java
@@ -37,4 +37,11 @@ public class AuthController {
         authCommandService.logout(request);
         return new BaseResponse<>(BaseResponseCode.LOGOUT_SUCCESS);
     }
+
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 기능입니다.")
+    @DeleteMapping("/withdraw")
+    public BaseResponse<String> withdraw(HttpServletRequest request) {
+        authCommandService.withdraw(request);
+        return new BaseResponse<>(BaseResponseCode.WITHDRAW_SUCCESS);
+    }
 }

--- a/src/main/java/ject/mycode/domain/auth/service/AuthCommandService.java
+++ b/src/main/java/ject/mycode/domain/auth/service/AuthCommandService.java
@@ -9,4 +9,5 @@ public interface AuthCommandService {
     AuthRes.LoginResultDTO login(AuthReq.SocialLoginDTO request);
     JwtRes reissueToken(String refreshToken);
     void logout(HttpServletRequest request);
+    void withdraw(HttpServletRequest request);
 }

--- a/src/main/java/ject/mycode/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/ject/mycode/domain/auth/service/AuthCommandServiceImpl.java
@@ -10,6 +10,7 @@ import ject.mycode.domain.auth.jwt.util.JwtProvider;
 import ject.mycode.domain.user.converter.UserConverter;
 import ject.mycode.domain.user.entity.User;
 import ject.mycode.domain.user.enums.UserRole;
+import ject.mycode.domain.user.enums.UserStatus;
 import ject.mycode.domain.user.repository.UserRepository;
 import ject.mycode.global.exception.AuthHandler;
 import ject.mycode.global.response.BaseResponseCode;
@@ -47,6 +48,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
                     .socialType(request.getSocialType())
                     .nickname(NicknameGenerator.generate()) // 랜덤 닉네임
                     .role(UserRole.NORMAL) // 권한 기본값
+                    .userStatus(UserStatus.ACTIVE)
                     .region(null)
                     .image(null)
                     .build();

--- a/src/main/java/ject/mycode/domain/auth/service/AuthCommandServiceImpl.java
+++ b/src/main/java/ject/mycode/domain/auth/service/AuthCommandServiceImpl.java
@@ -18,7 +18,9 @@ import ject.mycode.global.util.NicknameGenerator;
 import ject.mycode.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -86,6 +88,36 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             redisUtil.expire(accessToken, jwtProvider.getExpTime(accessToken), TimeUnit.MILLISECONDS);
             // RefreshToken 삭제
             redisUtil.delete(jwtProvider.getSocialId(accessToken));
+        } catch (ExpiredJwtException e) {
+            throw new AuthHandler(BaseResponseCode.TOKEN_EXPIRED);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void withdraw(HttpServletRequest request) {
+        try {
+            // AccessToken 추출
+            String accessToken = jwtProvider.resolveAccessToken(request);
+
+            // 회원 정보 중 socialId 추출
+            String socialId = jwtProvider.getSocialId(accessToken);
+
+            // DB에서 회원 조회
+            User user = userRepository.findBySocialId(socialId)
+                    .orElseThrow(() -> new AuthHandler(BaseResponseCode.USER_NOT_FOUND));
+
+            // 회원 상태 비활성화 처리 (soft delete)
+            user.setUserStatus(UserStatus.INACTIVE);
+            user.setInactiveDate(LocalDateTime.now());
+            userRepository.save(user);
+
+            // accessToken 블랙리스트 처리
+            redisUtil.set(accessToken, "withdraw");
+            redisUtil.expire(accessToken, jwtProvider.getExpTime(accessToken), TimeUnit.MILLISECONDS);
+
+            // refreshToken 삭제
+            redisUtil.delete(socialId);
         } catch (ExpiredJwtException e) {
             throw new AuthHandler(BaseResponseCode.TOKEN_EXPIRED);
         }

--- a/src/main/java/ject/mycode/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/ject/mycode/domain/content/service/ContentServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import ject.mycode.domain.content.dto.*;
 import ject.mycode.domain.content.enums.ContentType;
+import ject.mycode.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +31,7 @@ public class ContentServiceImpl implements ContentService {
 	private final ContentQueryRepositoryImpl contentQueryRepository;
 	private final ContentImageRepository contentImageRepository;
 	private final ContentTagRepository contentTagRepository;
+	private final UserRepository userRepository;
 
 	@Override
 	@Transactional
@@ -110,6 +112,13 @@ public class ContentServiceImpl implements ContentService {
 
 
 	public List<ContentRegionRes> getRecommendedContents(Long userId) {
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new CustomException(BaseResponseCode.USER_NOT_FOUND));
+
+		if (user.getRegion() == null) {
+			throw new CustomException(BaseResponseCode.USER_REGION_NOT_SET);
+		}
+
 		return contentQueryRepository.findRecommendedByUserRegion(userId);
 	}
 }

--- a/src/main/java/ject/mycode/domain/user/entity/User.java
+++ b/src/main/java/ject/mycode/domain/user/entity/User.java
@@ -12,6 +12,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "\"user\"")
 @Builder
@@ -45,8 +47,11 @@ public class User extends BaseEntity {
 	@Column(nullable = false)
 	private UserStatus userStatus;
 
+	// 탈퇴한 시간 저장용
+	private LocalDateTime inactiveDate;
+
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "region_id", nullable = false)
+	@JoinColumn(name = "region_id", nullable = true)
 	private Region region;
 
 	public void changeProfileImage(String image) {
@@ -59,5 +64,13 @@ public class User extends BaseEntity {
 
 	public void saveRecommendRegion(Region region) {
 		this.region = region;
+	}
+
+	public void setUserStatus(UserStatus userStatus) {
+		this.userStatus = userStatus;
+	}
+
+	public void setInactiveDate(LocalDateTime now) {
+		this.inactiveDate = now;
 	}
 }

--- a/src/main/java/ject/mycode/domain/user/entity/User.java
+++ b/src/main/java/ject/mycode/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import ject.mycode.domain.region.entity.Region;
 import ject.mycode.domain.user.enums.SocialType;
 import ject.mycode.domain.user.enums.UserRole;
+import ject.mycode.domain.user.enums.UserStatus;
 import ject.mycode.global.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -39,6 +40,10 @@ public class User extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private UserRole role;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private UserStatus userStatus;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "region_id", nullable = false)

--- a/src/main/java/ject/mycode/domain/user/enums/UserStatus.java
+++ b/src/main/java/ject/mycode/domain/user/enums/UserStatus.java
@@ -1,0 +1,5 @@
+package ject.mycode.domain.user.enums;
+
+public enum UserStatus {
+    ACTIVE, INACTIVE;
+}

--- a/src/main/java/ject/mycode/global/response/BaseResponseCode.java
+++ b/src/main/java/ject/mycode/global/response/BaseResponseCode.java
@@ -12,6 +12,7 @@ public enum BaseResponseCode {
 	LOGIN_SUCCESS(true, 1000, "로그인 성공", HttpStatus.OK),
 	TOKEN_REISSUE_SUCCESS(true, 1001, "토큰 재발급이 완료되었습니다.", HttpStatus.OK),
 	LOGOUT_SUCCESS(true, 1002, "로그아웃이 완료되었습니다.", HttpStatus.OK),
+	WITHDRAW_SUCCESS(true, 1003, "회원탈퇴가 완료되었습니다.", HttpStatus.OK),
 
 	// 1100 ~ 1199 : 컨텐츠 관련
 	ADD_FAVORITE(true, 1100, "관심목록에 추가했습니다.", HttpStatus.CREATED),
@@ -47,9 +48,9 @@ public enum BaseResponseCode {
 	// 2100 ~ 2199 : 컨텐츠 관련
 	CONTENT_NOT_EXIST(false, 2100, "존재하지 않는 컨텐츠입니다.", HttpStatus.NOT_FOUND),
 	FAVORITE_NOT_EXIST(false, 2101, "존재하지 않는 즐겨찾기입니다.", HttpStatus.NOT_FOUND),
+	USER_REGION_NOT_SET(false, 2102, "사용자 지역 정보가 설정되지 않았습니다.", HttpStatus.BAD_REQUEST),
 
 	//2200 ~ 2299 : 일정 관련
-
 	VALIDATION_FAILED(false, 2999, "잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
 	SCHEDULE_NOT_EXIST(false, 2200, "해당 일정이 없습니다.", HttpStatus.NOT_FOUND),
 
@@ -76,8 +77,7 @@ public enum BaseResponseCode {
 	INVALID_TOKEN(false, 4004, "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
 	FORBIDDEN(false, 4030, "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
 	UNAUTHORIZED(false, 4010, "인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
-	TOKEN_EXPIRED(false, 4011, "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
-	;
+	TOKEN_EXPIRED(false, 4011, "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),;
 
 
 	private final Boolean status;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
         enabled: false
 
   jwt:
-    secret: VGhpcyBpcyBhIHZlcnkgc2VjdXJlIGp3dCBzZWNyZXQga2V5IHdpdGggNjQgYnl0ZXM=
+    secret: ${JWT_SECRET}
     token:
       access-expiration-time: 3600000 #1시간
       refresh-expiration-time: 604800000 #7일


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #58 

## 📝 작업 내용
- [x] user 컬럼에 userstatus, inactivedate 추가 (유저 상태와 탈퇴한 날짜 관리를 위함)
- [x] region null=true 변경 후, 콘텐츠 추천 시 지역 저장이 안되어있다면 예외 처리하게 수정
- [x] user 탈퇴 시, 데이터 삭제하지 않고 userstatus만 inactive으로 변경 & 토큰 사용하지 못하게 처리

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
