### PR TITLE
fix: 콘텐츠 일정 조회 시 중복 제거 및 전체 개수 계산 방식 개선

### DIFF
--- a/src/main/java/ject/mycode/domain/content/repository/custom/ContentQueryRepositoryImpl.java
+++ b/src/main/java/ject/mycode/domain/content/repository/custom/ContentQueryRepositoryImpl.java
@@ -422,46 +422,47 @@ public class ContentQueryRepositoryImpl implements ContentQueryRepository {
 	public Page<SchedulesInfoRes> findSchedulesByDate(Pageable pageable, LocalDate day) {
 		QContentImage contentImageSub = new QContentImage("contentImageSub");
 
-		List<SchedulesInfoRes> schedules = qf
-			.select(Projections.constructor(
-				SchedulesInfoRes.class,
-				content.id,
-				content.title,
-				contentImage.imageUrl,
-				content.address,
-				content.startDate,
-				content.endDate
-			))
-			.from(schedule)
-			.join(schedule.content, content)
-			.leftJoin(contentImage).on(
-				contentImage.id.eq(
-					JPAExpressions
-						.select(contentImageSub.id.min())
-						.from(contentImageSub)
-						.where(contentImageSub.content.eq(content))
-				)
-			)
-			.where(
-				content.startDate.loe(day),
-				content.endDate.goe(day),
-				content.status.eq(ContentStatus.ACTIVE)
-			)
-			.orderBy(content.endDate.asc())
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
+        List<SchedulesInfoRes> schedules = qf
+                .select(Projections.constructor(
+                        SchedulesInfoRes.class,
+                        content.id,
+                        content.title,
+                        contentImage.imageUrl,
+                        content.address,
+                        content.startDate,
+                        content.endDate
+                ))
+                .distinct()
+                .from(schedule)
+                .join(schedule.content, content)
+                .leftJoin(contentImage).on(
+                        contentImage.id.eq(
+                                JPAExpressions
+                                        .select(contentImageSub.id.min())
+                                        .from(contentImageSub)
+                                        .where(contentImageSub.content.eq(content))
+                        )
+                )
+                .where(
+                        content.startDate.loe(day),
+                        content.endDate.goe(day),
+                        content.status.eq(ContentStatus.ACTIVE)
+                )
+                .orderBy(content.endDate.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
 
-		Long total = qf
-			.select(content.count())
-			.from(schedule)
-			.join(schedule.content, content)
-			.where(
-				content.startDate.loe(day),
-				content.endDate.goe(day),
-				content.status.eq(ContentStatus.ACTIVE)
-			)
-			.fetchOne();
+        Long total = qf
+                .select(content.id.countDistinct())
+                .from(schedule)
+                .join(schedule.content, content)
+                .where(
+                        content.startDate.loe(day),
+                        content.endDate.goe(day),
+                        content.status.eq(ContentStatus.ACTIVE)
+                )
+                .fetchOne();
 
 		return new PageImpl<>(schedules, pageable, total != null ? total : 0);
 	}


### PR DESCRIPTION
## 📝 작업 내용
콘텐츠 일정 조회 API(/schedules)에서 동일한 콘텐츠가 여러 번 반환되는 문제가 있어 이를 수정했습니다. 해당 문제는 schedule 테이블에 동일한 content_id를 가진 레코드가 여러 개 존재하여 조회 시 중복 조인이 발생하는 것이 원인이었습니다.

### 🛠 변경 사항
**1. 조회 결과 중복 제거 (distinct) 적용**
content 에 대한 join 과정에서 동일한 콘텐츠가 여러 번 조인되는 문제를 방지하기 위해
select 절에 distinct를 추가했습니다.
```
.select(Projections.constructor(...))
.distinct()
```
**2. 전체 개수 조회 시 DISTINCT COUNT 적용**
기존 total count는 schedule 개수를 기준으로 계산되어
중복된 콘텐츠 수가 잘못 계산되는 문제가 있었습니다.
이를 content.id.countDistinct()로 수정하여
컨텐츠 단위로 정확한 전체 개수를 계산하도록 변경했습니다.
```
Long total = qf
    .select(content.id.countDistinct())
    .from(schedule)
    .join(schedule.content, content)
    .where(...)
    .fetchOne();
```