### PR TITLE
[FEAT] 검색 시 종료된 컨텐츠가 노출 안되게 수정 & 검색 시 정렬 로직을 개선

### DIFF
--- a/src/main/java/ject/mycode/domain/search/repository/custom/SearchQueryRepositoryImpl.java
+++ b/src/main/java/ject/mycode/domain/search/repository/custom/SearchQueryRepositoryImpl.java
@@ -8,12 +8,15 @@ import ject.mycode.domain.content.entity.Content;
 import ject.mycode.domain.content.entity.QContent;
 import ject.mycode.domain.content.enums.ContentType;
 import ject.mycode.domain.search.entity.QSearchKeyword;
+import ject.mycode.domain.user.enums.ContentStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -35,7 +38,11 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
         return queryFactory
                 .selectDistinct(content)   // ⭐ 중복 해결 핵심
                 .from(content)
-                .where(condition)
+                .where(
+                        content.status.eq(ContentStatus.ACTIVE)
+                                .and(isUpcomingEvent())  // ⭐ 추가
+                                .and(condition)
+                )
                 .orderBy(orderSpecifier)
                 .offset(offset)
                 .limit(limit)
@@ -56,10 +63,16 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
     }
 
     private OrderSpecifier<?> getOrderSpecifier(String sort) {
-        if ("views".equalsIgnoreCase(sort)) {
-            return content.views.desc();
+        switch (sort != null ? sort.toLowerCase() : "") {
+            case "views":
+                return content.views.desc();
+            case "date":  // ⭐ 날짜 임박 순 (startDate ASC)
+                return content.startDate.asc();
+            case "enddate":  // 종료일 임박 순
+                return content.endDate.asc();
+            default:
+                return content.startDate.asc();  // 기본: 날짜순
         }
-        return content.createdAt.desc();
     }
 
     @Override
@@ -137,8 +150,12 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
         }
 
         return queryFactory
-                .selectDistinct(content)  // ⭐ 혹시 모를 중복 예방
+                .selectDistinct(content)  // 혹시 모를 중복 예방
                 .from(content)
+                .where(
+                        content.status.eq(ContentStatus.ACTIVE)  // 기존
+                                .and(isUpcomingEvent())                // ⭐ 추가
+                )
                 .orderBy(orderSpecifier)
                 .offset(offset)
                 .limit(limit)
@@ -153,6 +170,12 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
                         .from(content)
                         .fetchOne()
         );
+    }
+
+    private BooleanExpression isUpcomingEvent() {
+        LocalDateTime now = LocalDateTime.now();
+        return content.startDate.goe(LocalDate.from(now))  // 시작일이 현재 이후
+                .or(content.endDate.goe(LocalDate.from(now))); // 종료일이 현재 이후
     }
 
 }

--- a/src/main/java/ject/mycode/domain/search/repository/custom/SearchQueryRepositoryImpl.java
+++ b/src/main/java/ject/mycode/domain/search/repository/custom/SearchQueryRepositoryImpl.java
@@ -64,11 +64,9 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
 
     private OrderSpecifier<?> getOrderSpecifier(String sort) {
         switch (sort != null ? sort.toLowerCase() : "date") {  // 기본값 date
-            case "views":
-                return content.views.desc();
             case "date":
                 return content.startDate.asc();  // ⭐ 임박 순 (가까운 날짜 먼저)
-            case "popular":
+            case "views":
                 return content.views.desc();
             default:
                 return content.startDate.asc();  // 기본: 날짜 임박 순

--- a/src/main/java/ject/mycode/domain/search/repository/custom/SearchQueryRepositoryImpl.java
+++ b/src/main/java/ject/mycode/domain/search/repository/custom/SearchQueryRepositoryImpl.java
@@ -63,15 +63,15 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
     }
 
     private OrderSpecifier<?> getOrderSpecifier(String sort) {
-        switch (sort != null ? sort.toLowerCase() : "") {
+        switch (sort != null ? sort.toLowerCase() : "date") {  // 기본값 date
             case "views":
                 return content.views.desc();
-            case "date":  // ⭐ 날짜 임박 순 (startDate ASC)
-                return content.startDate.asc();
-            case "enddate":  // 종료일 임박 순
-                return content.endDate.asc();
+            case "date":
+                return content.startDate.asc();  // ⭐ 임박 순 (가까운 날짜 먼저)
+            case "popular":
+                return content.views.desc();
             default:
-                return content.startDate.asc();  // 기본: 날짜순
+                return content.startDate.asc();  // 기본: 날짜 임박 순
         }
     }
 
@@ -173,9 +173,9 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
     }
 
     private BooleanExpression isUpcomingEvent() {
-        LocalDateTime now = LocalDateTime.now();
-        return content.startDate.goe(LocalDate.from(now))  // 시작일이 현재 이후
-                .or(content.endDate.goe(LocalDate.from(now))); // 종료일이 현재 이후
+        LocalDate now = LocalDate.now();
+        return content.startDate.goe(now)
+                .or(content.endDate.goe(now));
     }
 
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #73 

## 📝 작업 내용
### 정렬 순서
1. where(...) ⭐ 핵심 필터링
```
content.status.eq(ContentStatus.ACTIVE)           → ACTIVE 상태만
.and(isUpcomingEvent())                          → 진행중/예정 이벤트만  
.and(condition)                                  → 키워드 검색 조건
```
- 결과: ACTIVE + 미래 이벤트 + 키워드 일치 컨텐츠만 생존

2. orderBy(orderSpecifier)
필터링된 결과 정렬
- views → 조회수 내림차순
- date → startDate 오름차순 (임박순)
 
3. offset(offset)
결과 중 offset만큼 건너뛰기 (페이징 시작점)

4. limit(limit) ⭐ 마지막 제한
- 최대 limit개만 반환
